### PR TITLE
chore: update Chatlayer URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Set it true if your bot has welcome/intro message.
 
 ### CHATLAYER_BOT_ID
 For detailed nlp data the bot id has to be set up. You can copy this from the url of your chatbot on chatlayer surface.
-E.g. my url is 'https://cms.staging.chatlayer.ai/bots/abcdabcd/DRAFT' then the bot id is: `abcdabcd`
+E.g. my url is 'https://app.chatlayer.ai/bots/abcdabcd/DRAFT' then the bot id is: `abcdabcd`
 
 ### CHATLAYER_VERSION
 Set which version you use. It can be `DRAFT` of `LIVE`. The default value is `DRAFT`.


### PR DESCRIPTION
Hi

We've changed our URLs from "cms(.staging).chatlayer" to "app.chatlayer". This change reflects this in your docs as well.

See the following for more information: https://docs.chatlayer.ai/bot-answers/publishing-your-bot/publishing-new

Cheers